### PR TITLE
Add capability to run files directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ pwint("Hewwo Wowrld")
 
 <h4 align="left">Run</h4>
 
-```py
-rwun("test.pyowo")
+Either run from the interpreter directly:
+```sh
+python pythowo.py test.pyowo
+```
+
+Or run in an interactive shell:
+```sh
+python shwell.py
+> rwun("test.pyowo")
 ```
 
 <h4 align="left">Output</h4>

--- a/pythowo.py
+++ b/pythowo.py
@@ -2204,11 +2204,11 @@ def run(fn, text):
   return result.value, result.error
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1:
-        with open(sys.argv[1], 'r') as fiwe:
-            cwode = fiwe.read()
-        result, error = run(sys.argv[1], cwode)
-        if error:
-            print(error.as_string())
-        sys.exit(0 if not error else 1)
+  if len(sys.argv) > 1:
+    with open(sys.argv[1], 'r') as fiwe:
+      cwode = fiwe.read()
+    result, error = run(sys.argv[1], cwode)
+    if error:
+      print(error.as_string())
+    sys.exit(0 if not error else 1)
 

--- a/pythowo.py
+++ b/pythowo.py
@@ -9,6 +9,7 @@ from stwings_with_awwows import *
 import string
 import os
 import math
+import sys
 
 #######################################
 # CONSTANTS
@@ -2201,3 +2202,13 @@ def run(fn, text):
   result = interpreter.visit(ast.node, context)
 
   return result.value, result.error
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        with open(sys.argv[1], 'r') as fiwe:
+            cwode = fiwe.read()
+        result, error = run(sys.argv[1], cwode)
+        if error:
+            print(error.as_string())
+        sys.exit(0 if not error else 1)
+


### PR DESCRIPTION
## Overview

It would be convenient to be able to run files directly, enabling pythOwO to be better adopted as a serious scripting language for serious programmers. This PR adds this capability by:
- Adding behavior to `pythowo.py` which checks for arguments and runs the first argument as a file if present.
- Documenting the new run syntax in the appropriate README section.

## Changelog Entry

> Add ability to run files directly through the pythOwO interpreter

## Checklist

- [X] I have performed a self-review of my code
- [X] I have documented my changes
- [ ] I have added unit testing for my changes
