### PR TITLE
Add string comparsion functionality

### DIFF
--- a/pythowo.py
+++ b/pythowo.py
@@ -1514,6 +1514,42 @@ class String(Value):
     else:
       return None, Value.illegal_operation(self, other)
 
+  def get_comparison_eq(self, other):
+    if isinstance(other, String):
+      return Number(int(self.value == other.value)).set_context(self.context), None
+    else:
+      return None, Value.illegal_operation(self, other)
+
+  def get_comparison_ne(self, other):
+    if isinstance(other, String):
+      return Number(int(self.value != other.value)).set_context(self.context), None
+    else:
+      return None, Value.illegal_operation(self, other)
+
+  def get_comparison_lt(self, other):
+    if isinstance(other, String):
+      return Number(int(self.value < other.value)).set_context(self.context), None
+    else:
+      return None, Value.illegal_operation(self, other)
+
+  def get_comparison_gt(self, other):
+    if isinstance(other, String):
+      return Number(int(self.value > other.value)).set_context(self.context), None
+    else:
+      return None, Value.illegal_operation(self, other)
+
+  def get_comparison_lte(self, other):
+    if isinstance(other, String):
+      return Number(int(self.value <= other.value)).set_context(self.context), None
+    else:
+      return None, Value.illegal_operation(self, other)
+
+  def get_comparison_gte(self, other):
+    if isinstance(other, String):
+      return Number(int(self.value >= other.value)).set_context(self.context), None
+    else:
+      return None, Value.illegal_operation(self, other)
+
   def is_true(self):
     return len(self.value) > 0
 


### PR DESCRIPTION
## Overview

pythOwO doesn't currently have `String` comparison functionality. This fixes that.
- Adds comparison operator definitions to `String`
- Resolves #6 

## Changelog Entry

> Add ability to compare `String`s

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have documented my changes
- [ ] I have added unit testing for my changes
