### PR TITLE
add: example/pwint_sqware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cython_debug/
 #.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+.DS_Store

--- a/exwamples/pwint_sqware.pyowo
+++ b/exwamples/pwint_sqware.pyowo
@@ -1,0 +1,8 @@
+# Get A Nuwumber
+pwint("Enter thew nuwumber of side of sqware: ")
+pwease nuwumber = inpwt_int()
+
+# First Lowop
+FOR uwu = 0 TO nuwumber THWEN
+    pwint("ω"*nuwumber)
+END


### PR DESCRIPTION
This pull request is for adding more example to pythOwO.

**Changes proposed:**
🙈 update .gitignore to exclude .DS_Store that always appear in macOS as well
🍱 add pwint_sqware.pyowo - smol simple sqware pwrinting

```
Enter thew nuwumber of side of sqware:
5
ωωωωω
ωωωωω
ωωωωω
ωωωωω
ωωωωω
```

**Note to revieuwuers:**
Nothing just uwu.